### PR TITLE
Use empty object as a context instead of request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ var timer = require('contimer'),
 
 module.exports = function requestTimeMiddleware(cb) {
     return function(req, res, next) {
-        timer.start(req, TIMER_LABEL);
+        var timerStop = timer.start({}, TIMER_LABEL);
 
         res
             .on('finish', onFinish)
             .on('cancel', onCancel);
 
         function onFinish() {
-            var timeObj = timer.stop(req, TIMER_LABEL);
+            var timeObj = timerStop();
             cb(timeObj.time, req);
         }
 


### PR DESCRIPTION
I think it's not a good idea to use `req` as a context, as `contimer` calls `defineProperty` on it's context, which, in general, is not cheap.

/cc @kaero